### PR TITLE
ts-node-devのバージョンを8.6.2から8.5.4にダウングレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "ts-node": "^8.6.2",
+        "ts-node": "^8.5.4",
         "ts-node-dev": "^1.0.0-pre.44",
         "typescript": "^3.7.5"
       }
@@ -757,26 +757,26 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
       "dev": true,
       "dependencies": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
+        "yn": "^3.0.0"
       },
       "bin": {
         "ts-node": "dist/bin.js",
         "ts-script": "dist/script.js"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=4.2.0"
       },
       "peerDependencies": {
-        "typescript": ">=2.7"
+        "typescript": ">=2.0"
       }
     },
     "node_modules/ts-node-dev": {
@@ -1494,16 +1494,16 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
+        "yn": "^3.0.0"
       }
     },
     "ts-node-dev": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/enuii3/typescript#readme",
   "devDependencies": {
-    "ts-node": "^8.6.2",
+    "ts-node": "^8.5.4",
     "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.7.5"
   }


### PR DESCRIPTION
8.6.2だと監視中にエラーを表示してくれないというバグがあるためのダウングレード